### PR TITLE
Include conflicted file names in cherry-pick PR description

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30246,8 +30246,8 @@ const github = __importStar(__nccwpck_require__(5438));
 const core = __importStar(__nccwpck_require__(2186));
 const ERROR_PR_REVIEW_FROM_AUTHOR = 'Review cannot be requested from pull request author';
 const CONFLICTS_DETECTED_WARNING = `## Cherry pick conflicts detected - please resolve conflicts and remove this line (cherrypick-conflict).\n\n`;
-function createPullRequest(inputs, prBranch, conflict) {
-    return __awaiter(this, void 0, void 0, function* () {
+function createPullRequest(inputs_1, prBranch_1, conflict_1) {
+    return __awaiter(this, arguments, void 0, function* (inputs, prBranch, conflict, conflictedFiles = []) {
         const octokit = github.getOctokit(inputs.token);
         if (!github.context.payload) {
             core.info(`Error: no payload in github.context`);
@@ -30280,7 +30280,11 @@ function createPullRequest(inputs, prBranch, conflict) {
             }
             if (conflict) {
                 title = `CONFLICT!!!! ${title}`;
-                body = `${CONFLICTS_DETECTED_WARNING}${body}`;
+                let conflictInfo = CONFLICTS_DETECTED_WARNING;
+                if (conflictedFiles.length > 0) {
+                    conflictInfo += `### Conflicted files\n${conflictedFiles.map(f => `- \`${f}\``).join('\n')}\n\n`;
+                }
+                body = `${conflictInfo}${body}`;
             }
             core.info(`Using title '${title}'`);
             core.info(`Using body '${body}'`);
@@ -30465,6 +30469,7 @@ function run() {
             // Cherry pick
             core.startGroup('Cherry picking');
             let conflict = false;
+            let conflictedFiles = [];
             const result = yield gitExecution([
                 'cherry-pick',
                 '-m',
@@ -30492,7 +30497,7 @@ function run() {
                     '--diff-filter=U'
                 ]);
                 if (conflictResult.stdout.trim()) {
-                    const conflictedFiles = conflictResult.stdout.trim().split('\n');
+                    conflictedFiles = conflictResult.stdout.trim().split('\n');
                     core.info(`Found ${conflictedFiles.length} files with conflicts: ${conflictedFiles.join(', ')}`);
                     // Add all conflicted files
                     yield gitExecution(['add', ...conflictedFiles]);
@@ -30517,7 +30522,7 @@ function run() {
             core.endGroup();
             // Create pull request
             core.startGroup('Opening pull request');
-            const pull = yield (0, github_helper_1.createPullRequest)(inputs, prBranch, conflict);
+            const pull = yield (0, github_helper_1.createPullRequest)(inputs, prBranch, conflict, conflictedFiles);
             core.setOutput('data', JSON.stringify(pull.data));
             core.setOutput('number', pull.data.number);
             core.setOutput('html_url', pull.data.html_url);

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -28,7 +28,8 @@ export interface Inputs {
 export async function createPullRequest(
   inputs: Inputs,
   prBranch: string,
-  conflict: boolean
+  conflict: boolean,
+  conflictedFiles: string[] = []
 ): Promise<any> {
   const octokit = github.getOctokit(inputs.token)
   if (!github.context.payload) {
@@ -66,7 +67,11 @@ export async function createPullRequest(
 
     if (conflict) {
       title = `CONFLICT!!!! ${title}`
-      body = `${CONFLICTS_DETECTED_WARNING}${body}`
+      let conflictInfo = CONFLICTS_DETECTED_WARNING
+      if (conflictedFiles.length > 0) {
+        conflictInfo += `### Conflicted files\n${conflictedFiles.map(f => `- \`${f}\``).join('\n')}\n\n`
+      }
+      body = `${conflictInfo}${body}`
     }
     core.info(`Using title '${title}'`)
     core.info(`Using body '${body}'`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export async function run(): Promise<void> {
     // Cherry pick
     core.startGroup('Cherry picking')
     let conflict = false
+    let conflictedFiles: string[] = []
     const result = await gitExecution(
       [
         'cherry-pick',
@@ -110,7 +111,7 @@ export async function run(): Promise<void> {
       ])
 
       if (conflictResult.stdout.trim()) {
-        const conflictedFiles = conflictResult.stdout.trim().split('\n')
+        conflictedFiles = conflictResult.stdout.trim().split('\n')
         core.info(
           `Found ${conflictedFiles.length} files with conflicts: ${conflictedFiles.join(', ')}`
         )
@@ -141,7 +142,12 @@ export async function run(): Promise<void> {
 
     // Create pull request
     core.startGroup('Opening pull request')
-    const pull = await createPullRequest(inputs, prBranch, conflict)
+    const pull = await createPullRequest(
+      inputs,
+      prBranch,
+      conflict,
+      conflictedFiles
+    )
     core.setOutput('data', JSON.stringify(pull.data))
     core.setOutput('number', pull.data.number)
     core.setOutput('html_url', pull.data.html_url)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -112,7 +112,8 @@ describe('run main', () => {
         cherryPickBranch: ''
       }),
       'cherry-pick-target-branch-XXXXXX',
-      false
+      false,
+      []
     )
   })
 
@@ -135,7 +136,8 @@ describe('run main', () => {
         cherryPickBranch: 'my-custom-branch'
       }),
       'my-custom-branch',
-      false
+      false,
+      []
     )
   })
 
@@ -162,7 +164,8 @@ describe('run main', () => {
         cherryPickBranch: 'my-custom-branch'
       }),
       'my-custom-branch',
-      false
+      false,
+      []
     )
   })
 })


### PR DESCRIPTION
# Include conflicted file names in cherry-pick PR description

## Summary
When a cherry-pick has conflicts and `commit-conflicts` is enabled, the PR body now lists the specific files that had conflicts under a "Conflicted files" section. Previously, the PR only showed a generic "conflicts detected" warning without indicating which files were affected.

Changes:
- Pass `conflictedFiles` array from `index.ts` to `createPullRequest` in `github-helper.ts`
- Render the list of conflicted files as a markdown list in the PR body
- Update tests to match new function signature

## Review & Testing Checklist for Human
- [ ] Verify the conflicted files list renders correctly in a real cherry-pick PR with conflicts
- [ ] Confirm no-conflict cherry-picks still work (empty `conflictedFiles` array, no extra text added)

### Notes
Requested by Prem. Session: this Devin session.

Devin Session: https://staging.itsdev.in/sessions/b867228b5b1646cd80bccc3a108e9144
<!-- devin-review-badge-staging-begin -->

---

<a href="https://staging.itsdev.in/review/exafunction/github-cherry-pick-action/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Staging: Open in Devin">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
